### PR TITLE
Mejorando el aspecto del Campo de Contraseña:

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,7 +51,7 @@ android {
 
 dependencies {
 
-    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
     implementation("androidx.activity:activity-compose:1.8.0")
     implementation(platform("androidx.compose:compose-bom:2023.03.00"))
@@ -59,6 +59,10 @@ dependencies {
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
+
+    // Compose Material Icons Extended
+    implementation("androidx.compose.material:material-icons-extended:1.5.4")
+
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/src/main/java/com/example/loginformjetpackcompose/MainActivity.kt
+++ b/app/src/main/java/com/example/loginformjetpackcompose/MainActivity.kt
@@ -1,4 +1,4 @@
-@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3Api::class)
+@file:OptIn(ExperimentalMaterial3Api::class)
 
 package com.example.loginformjetpackcompose
 
@@ -8,8 +8,13 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
@@ -21,6 +26,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.loginformjetpackcompose.ui.theme.LoginFormJetpackComposeTheme
@@ -72,13 +79,20 @@ private fun PasswordField(
     value: String,
     onValueChange: (String) -> Unit
 ) {
-
+    var passVisible by remember { mutableStateOf(false) }
     OutlinedTextField(
         value = value,
         onValueChange = onValueChange,
         singleLine = true,
         maxLines = 1,
-        label = { Text(text = "Password") }
+        label = { Text(text = "Password") },
+        visualTransformation = if(passVisible) VisualTransformation.None else PasswordVisualTransformation(),
+        trailingIcon = {
+            IconToggleButton(checked = passVisible, onCheckedChange = { passVisible = it }) {
+                val icon = if(passVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility
+                Icon(imageVector = icon, contentDescription = null)
+            }
+        }
     )
 }
 


### PR DESCRIPTION
- El texto ingresado en el PasswordField, por defecto se muestra oculto al usuario (solo puntos) al tratarse de una contraseña.
- Agregamos un icnono al final del PasswordField, el cual indica si queremos mostrar u ocultar el texto ingresado.
- Agregamos la libreria de Compose Material Icons Extended en el archivo build.gradle.kts (:app).