### PR TITLE
Agregando libreria Compose Navigation:

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,6 +62,8 @@ dependencies {
 
     // Compose Material Icons Extended
     implementation("androidx.compose.material:material-icons-extended:1.5.4")
+    // Compose Navigation
+    implementation("androidx.navigation:navigation-compose:2.7.4")
 
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")


### PR DESCRIPTION
- Importamos la libreria Compose Navigation en el archivo build.gradle.kts (:app), que permite la navegación entre Composable´s.